### PR TITLE
Adding a few familiar cli commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 out.wasm
+node_modules/

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,24 @@
+// This file is necessary to be CommonJS because meow depends on `module.parent`
+// which doesn't exist if the parent is an ES module.
+
+const meow = require('meow');
+
+const cli = meow(`
+  Usage
+    $ schism <input>
+
+  Options
+    --version             Show the version number
+    --help                Show the help message
+    -o, --out [out.wasm]  Specify a file to write the wasm to
+`, {
+  flags: {
+    out: {
+      type: 'string',
+      alias: 'o',
+      default: 'out.wasm'
+    }
+  }
+});
+
+module.exports = cli;

--- a/package.json
+++ b/package.json
@@ -20,5 +20,11 @@
   "bugs": {
     "url": "https://github.com/google/schism/issues"
   },
-  "homepage": "https://github.com/google/schism#readme"
+  "homepage": "https://github.com/google/schism#readme",
+  "bin": {
+    "schism": "./schism.sh"
+  },
+  "dependencies": {
+    "meow": "^5.0.0"
+  }
 }

--- a/run-schism.mjs
+++ b/run-schism.mjs
@@ -20,12 +20,13 @@ import { stage0_compile, stage1_compile, stage2_compile } from './run-utils.mjs'
 import fs from 'fs';
 import util from 'util';
 import process from 'process';
+import cli from './cli';
 
 async function runSchism() {
     // set up the input port
-    const input_file = process.argv[2] || "./schism/compiler.ss";
+    const input_file = cli.input[0] || "./schism/compiler.ss";
     const compiler_output = await stage1_compile(fs.readFileSync(input_file));
-    fs.writeFileSync('out.wasm', compiler_output);
+    fs.writeFileSync(cli.flags.out, compiler_output);
 }
 
 runSchism().catch((e) => {


### PR DESCRIPTION
This adds a few familiar cli commands, `--help`, and `--version`.

More importantly it adds `--out` to specify where the output wasm is
written. Defaults to `out.wasm`.

Closes #30