### PR TITLE
Make it possible to run schism from another directory

### DIFF
--- a/root.js
+++ b/root.js
@@ -1,0 +1,5 @@
+const path = require('path');
+const root = __dirname;
+
+exports.path = root;
+exports.join = (...args) => path.join.apply(path, [root, ...args]); 

--- a/run-utils.mjs
+++ b/run-utils.mjs
@@ -19,9 +19,9 @@ import * as Schism from './rt/rt';
 import child_process from 'child_process';
 import fs from 'fs';
 import util from 'util';
-import { URL } from 'url';
+import root from './root';
 
-const compilerPath = new URL('./schism/compiler.ss', import.meta.url).pathname;
+const compilerPath = root.join('schism/compiler.ss');
 
 export const OPTIONS = {
     use_snapshot: true, // load schism-stage0.wasm if true instead of
@@ -73,7 +73,7 @@ function make_cache(thunk) {
 export const stage0_bytes = make_cache(() =>
   OPTIONS.stage0 ? (async function() {
     return OPTIONS.use_snapshot
-	? fs.readFileSync(new URL('./schism-stage0.wasm', import.meta.url).pathname)
+	? fs.readFileSync(root.join('schism-stage0.wasm'))
 	: await compileBootstrap()
   })() : undefined);
 // Compile bytes using the stage0 compiler.
@@ -81,8 +81,7 @@ export const stage0_compile = OPTIONS.stage0 ? make_compiler(stage0_bytes) : und
 export const stage1_bytes = make_cache(async () => {
   if (!OPTIONS.stage1) { return undefined; }
   const bytes = await stage0_compile(fs.readFileSync(compilerPath));
-  fs.writeFileSync(new URL('./schism-stage1.wasm', import.meta.url).pathname,
-    bytes);
+  fs.writeFileSync(root.join('schism-stage1.wasm'), bytes);
   return bytes;
 });
 
@@ -90,8 +89,7 @@ export const stage1_compile = OPTIONS.stage1 ? make_compiler(stage1_bytes) : und
 export const stage2_bytes = make_cache(async () => {
   if (!OPTIONS.stage2) { return undefined; }
   const bytes = await stage1_compile(fs.readFileSync(compilerPath));
-  fs.writeFileSync(new URL('./schism-stage2.wasm', import.meta.url).pathname,
-    bytes);
+  fs.writeFileSync(root.join('schism-stage2.wasm'), bytes);
   return bytes;
 });
 
@@ -99,6 +97,6 @@ export const stage2_compile = OPTIONS.stage2 ? make_compiler(stage2_bytes) : und
 export const stage3_bytes = make_cache(async () => {
   if (!OPTIONS.stage3) { return undefined; }
   const bytes = await stage2_compile(fs.readFileSync(compilerPath));
-  fs.writeFileSync(new URL('./schism-stage3.wasm', import.meta.url).pathname, bytes);
+  fs.writeFileSync(root.join('schism-stage3.wasm'), bytes);
   return bytes;
 });

--- a/run-utils.mjs
+++ b/run-utils.mjs
@@ -19,6 +19,9 @@ import * as Schism from './rt/rt';
 import child_process from 'child_process';
 import fs from 'fs';
 import util from 'util';
+import { URL } from 'url';
+
+const compilerPath = new URL('./schism/compiler.ss', import.meta.url).pathname;
 
 export const OPTIONS = {
     use_snapshot: true, // load schism-stage0.wasm if true instead of
@@ -70,30 +73,32 @@ function make_cache(thunk) {
 export const stage0_bytes = make_cache(() =>
   OPTIONS.stage0 ? (async function() {
     return OPTIONS.use_snapshot
-	? fs.readFileSync('schism-stage0.wasm')
+	? fs.readFileSync(new URL('./schism-stage0.wasm', import.meta.url).pathname)
 	: await compileBootstrap()
   })() : undefined);
 // Compile bytes using the stage0 compiler.
 export const stage0_compile = OPTIONS.stage0 ? make_compiler(stage0_bytes) : undefined;
 export const stage1_bytes = make_cache(async () => {
   if (!OPTIONS.stage1) { return undefined; }
-  const bytes = await stage0_compile(fs.readFileSync('./schism/compiler.ss'));
-  fs.writeFileSync('schism-stage1.wasm', bytes);
+  const bytes = await stage0_compile(fs.readFileSync(compilerPath));
+  fs.writeFileSync(new URL('./schism-stage1.wasm', import.meta.url).pathname,
+    bytes);
   return bytes;
 });
 
 export const stage1_compile = OPTIONS.stage1 ? make_compiler(stage1_bytes) : undefined;
 export const stage2_bytes = make_cache(async () => {
   if (!OPTIONS.stage2) { return undefined; }
-  const bytes = await stage1_compile(fs.readFileSync('./schism/compiler.ss'));
-  fs.writeFileSync('schism-stage2.wasm', bytes);
+  const bytes = await stage1_compile(fs.readFileSync(compilerPath));
+  fs.writeFileSync(new URL('./schism-stage2.wasm', import.meta.url).pathname,
+    bytes);
   return bytes;
 });
 
 export const stage2_compile = OPTIONS.stage2 ? make_compiler(stage2_bytes) : undefined;
 export const stage3_bytes = make_cache(async () => {
   if (!OPTIONS.stage3) { return undefined; }
-  const bytes = await stage2_compile(fs.readFileSync('./schism/compiler.ss'));
-  fs.writeFileSync('schism-stage3.wasm', bytes);
+  const bytes = await stage2_compile(fs.readFileSync(compilerPath));
+  fs.writeFileSync(new URL('./schism-stage3.wasm', import.meta.url).pathname, bytes);
   return bytes;
 });

--- a/schism.sh
+++ b/schism.sh
@@ -14,4 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-node --experimental-modules run-schism.mjs "$@"
+# Get the current directory. Thanks to 
+# https://gist.github.com/TheMengzor/968e5ea87e99d9c41782
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+
+node --experimental-modules $DIR/run-schism.mjs "$@"


### PR DESCRIPTION
I wanted to symlink to `schism.sh` in my PATH so that I could play
around with it in another project folder. This makes that work, fixing
all of the pathing that was using `pwd`.