### PR TITLE
Implements initial version of schemeFromJs

### DIFF
--- a/rt/rt.mjs
+++ b/rt/rt.mjs
@@ -66,6 +66,19 @@ function js_from_scheme(ptr) {
     }
 }
 
+// Convert a JS value into a Scheme ptr
+function scheme_from_js(value) {
+    const type = typeof value;
+    switch(type) {
+        case 'number':
+            return value << TAG_SIZE;
+        case 'boolean':
+            return CONSTANTS[value];
+        default:
+            throw new Error(`Converting a ${type} has not been implemented`);
+    }
+}
+
 function fixnum_from_number(n) {
     return n << TAG_SIZE;
 }
@@ -162,6 +175,10 @@ export class Engine {
 
     jsFromScheme(ptr) {
         return js_from_scheme(ptr);
+    }
+
+    schemeFromJs(value) {
+        return scheme_from_js(value);
     }
 
     carOf(ptr) {

--- a/run-tests.mjs
+++ b/run-tests.mjs
@@ -26,9 +26,11 @@ import fs from 'fs';
 import process from 'process';
 import util from 'util';
 
+import * as addNumsTest from './test/add-nums-arg.mjs';
 import * as eqFalseTest from './test/eq-false-arg.mjs';
 
 const testModules = {
+    'test/add-nums-arg.ss': addNumsTest,
     'test/eq-false-arg.ss': eqFalseTest
 };
 
@@ -58,12 +60,12 @@ async function runTest(name, compile = compileWithHostScheme) {
         } else {
             raw_result = wasm.exports['do-test']();
             result = engine.jsFromScheme(raw_result);
+            assert.ok(result != false, "test failed");
         }
     } catch (e) {
         console.error(e.stack);
         throw e;
     }
-    assert.ok(result != false, "test failed");
 }
 
 async function getTests() {

--- a/run-tests.mjs
+++ b/run-tests.mjs
@@ -26,6 +26,12 @@ import fs from 'fs';
 import process from 'process';
 import util from 'util';
 
+import * as eqFalseTest from './test/eq-false-arg.mjs';
+
+const testModules = {
+    'test/eq-false-arg.ss': eqFalseTest
+};
+
 Error.stackTraceLimit = 20;
 
 async function runTest(name, compile = compileWithHostScheme) {
@@ -42,11 +48,7 @@ async function runTest(name, compile = compileWithHostScheme) {
     }
 
     // Set up mjs tests
-    const mjsFile = name.replace(".ss", ".mjs");
-    let testModule;
-    if (fs.existsSync(mjsFile)) {
-        testModule = await import(`./${mjsFile}`);
-    }
+    const testModule = testModules[name];
 
     let raw_result;
     let result;

--- a/run-tests.mjs
+++ b/run-tests.mjs
@@ -16,10 +16,10 @@
 
 import * as Schism from './rt/rt';
 import { compileWithHostScheme, OPTIONS,
-	 stage0_bytes, stage0_compile,
-	 stage1_bytes, stage1_compile,
-	 stage2_bytes, stage2_compile,
-	 stage3_bytes } from './run-utils';
+    stage0_bytes, stage0_compile,
+    stage1_bytes, stage1_compile,
+    stage2_bytes, stage2_compile,
+    stage3_bytes } from './run-utils';
 
 import assert from 'assert';
 import fs from 'fs';
@@ -38,31 +38,42 @@ async function runTest(name, compile = compileWithHostScheme) {
     // set up the input port
     const input_file = name.replace(".ss", ".input");
     if (fs.existsSync(input_file)) {
-	engine.setCurrentInputPort(fs.readFileSync(input_file));
+        engine.setCurrentInputPort(fs.readFileSync(input_file));
+    }
+
+    // Set up mjs tests
+    const mjsFile = name.replace(".ss", ".mjs");
+    let testModule;
+    if (fs.existsSync(mjsFile)) {
+        testModule = await import(`./${mjsFile}`);
     }
 
     let raw_result;
     let result;
     try {
-	raw_result = wasm.exports['do-test']();
-	result = engine.jsFromScheme(raw_result);
+        if(testModule) {
+            testModule.test(wasm, engine, assert);
+        } else {
+            raw_result = wasm.exports['do-test']();
+            result = engine.jsFromScheme(raw_result);
+        }
     } catch (e) {
-	console.error(e.stack);
-	throw e;
+        console.error(e.stack);
+        throw e;
     }
     assert.ok(result != false, "test failed");
 }
 
 async function getTests() {
     if (process.argv.length > 2) {
-	return process.argv.slice(2);
+        return process.argv.slice(2);
     } else {
-	let files = await util.promisify(fs.readdir)('test');
-	return (function* () {
-	    for (const name of files) {
-		yield `test/${name}`;
-	    }
-	})();
+        let files = await util.promisify(fs.readdir)('test');
+        return (function* () {
+            for (const name of files) {
+                yield `test/${name}`;
+            }
+        })();
     }
 }
 
@@ -70,58 +81,58 @@ async function runTests() {
     let failures = [];
     const files = await getTests();
     for (const test of files) {
-	if (test.endsWith(".ss")) {
-	    let local_failures = [];
-	    console.info(`Running test ${test}`);
-	    async function run_stage(name, compile) {
-		try {
-		    await runTest(test, compile);
-		    console.info(`  ${name} succeeded`);
-		} catch (e) {
-		    console.info(`  ${name} FAILED`);
-		    console.info(e.stack);
-		    local_failures.push([name]);
-		}
-	    }
-	    if (OPTIONS.stage0) {
-		await run_stage("stage0", stage0_compile);
-	    }
-	    if (OPTIONS.stage1) {
-		await run_stage("stage1", stage1_compile);
-	    }
-	    if (OPTIONS.stage2) {
-		await run_stage("stage2", stage2_compile);
-	    }
-	    if (local_failures.length > 0) {
-		failures.push([test, local_failures]);
-	    }
-	}
+        if (test.endsWith(".ss")) {
+            let local_failures = [];
+            console.info(`Running test ${test}`);
+            async function run_stage(name, compile) {
+                try {
+                    await runTest(test, compile);
+                    console.info(`  ${name} succeeded`);
+                } catch (e) {
+                    console.info(`  ${name} FAILED`);
+                    console.info(e.stack);
+                    local_failures.push([name]);
+                }
+            }
+            if (OPTIONS.stage0) {
+                await run_stage("stage0", stage0_compile);
+            }
+            if (OPTIONS.stage1) {
+                await run_stage("stage1", stage1_compile);
+            }
+            if (OPTIONS.stage2) {
+                await run_stage("stage2", stage2_compile);
+            }
+            if (local_failures.length > 0) {
+                failures.push([test, local_failures]);
+            }
+        }
     }
     return failures;
 }
 
 async function createSchismFromWasm(schism_bytes) {
     return async function(name) {
-	let engine = new Schism.Engine;
-	let schism = await engine.loadWasmModule(schism_bytes);
-	engine.setCurrentInputPort(fs.readFileSync(name));
-	engine.clearOutputBuffer();
-	schism.exports['compile-stdin->stdout']();
+        let engine = new Schism.Engine;
+        let schism = await engine.loadWasmModule(schism_bytes);
+        engine.setCurrentInputPort(fs.readFileSync(name));
+        engine.clearOutputBuffer();
+        schism.exports['compile-stdin->stdout']();
 
-	const compiled_bytes = new Uint8Array(engine.output_data);
-	fs.writeFileSync('out.wasm', compiled_bytes);
-	return compiled_bytes;
+        const compiled_bytes = new Uint8Array(engine.output_data);
+        fs.writeFileSync('out.wasm', compiled_bytes);
+        return compiled_bytes;
     };
 }
 
 // We should be at a fixpoint by now, so we compile stage3 only to check for equality.
 async function checkCompilerFixpoint() {
-  const stage2 = await stage2_bytes;
-  const stage3 = await stage3_bytes;
-  assert.equal(stage2.length, stage3.length);
-  for(const i in stage2) {
-    assert.equal(stage2[i], stage3[i], `stage2 and stage3 compilers differ at byte ${i}`);
-  }
+    const stage2 = await stage2_bytes;
+    const stage3 = await stage3_bytes;
+    assert.equal(stage2.length, stage3.length);
+    for(const i in stage2) {
+        assert.equal(stage2[i], stage3[i], `stage2 and stage3 compilers differ at byte ${i}`);
+    }
 }
 
 let results = runTests();

--- a/test/add-nums-arg.mjs
+++ b/test/add-nums-arg.mjs
@@ -1,0 +1,10 @@
+
+export function test(wasm, engine, assert) {
+  let rawResult = wasm.exports['do-test'](
+    engine.schemeFromJs(1),
+    engine.schemeFromJs(2)
+  );
+  let result = engine.jsFromScheme(rawResult);
+
+  assert.equal(result, 3, "Added the numbers and converted back.");
+}

--- a/test/add-nums-arg.ss
+++ b/test/add-nums-arg.ss
@@ -1,0 +1,21 @@
+;; Copyright 2018 Google LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the License);
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an AS IS BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(library
+    (trivial)
+  (export do-test)
+  (import (rnrs))
+
+  (define (do-test a b)
+   (+ a b)))

--- a/test/eq-false-arg.mjs
+++ b/test/eq-false-arg.mjs
@@ -1,0 +1,13 @@
+
+export function test(wasm, engine, assert) {
+  function testValue(value) {
+    let rawResult = wasm.exports['do-test'](
+      engine.schemeFromJs(value)
+    );
+    return engine.jsFromScheme(rawResult);
+  }
+
+  assert.equal(testValue(false), true);
+  assert.equal(testValue(true), false);
+}
+

--- a/test/eq-false-arg.ss
+++ b/test/eq-false-arg.ss
@@ -1,0 +1,21 @@
+;; Copyright 2018 Google LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the License);
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an AS IS BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(library
+    (trivial)
+  (export do-test)
+  (import (rnrs))
+
+  (define (do-test val)
+   (eq? #f val)))


### PR DESCRIPTION
This adds schemeFromJs to the runtime so that JavaScript values can be
passed to scheme functions. For now only numbers and booleans are
implemented.

For #33