### PR TITLE
Make stage-0 the default compile

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -11,12 +11,17 @@ const cli = meow(`
     --version             Show the version number
     --help                Show the help message
     -o, --out [out.wasm]  Specify a file to write the wasm to
+    --stage [0]           Specify which stage compiler to use
 `, {
   flags: {
     out: {
       type: 'string',
       alias: 'o',
       default: 'out.wasm'
+    },
+    stage: {
+      type: 'string',
+      default: '0'
     }
   }
 });

--- a/run-schism.mjs
+++ b/run-schism.mjs
@@ -25,8 +25,20 @@ import cli from './cli';
 async function runSchism() {
     // set up the input port
     const input_file = cli.input[0] || "./schism/compiler.ss";
-    const compiler_output = await stage1_compile(fs.readFileSync(input_file));
+    const compiler_output = await getCompile()(fs.readFileSync(input_file));
     fs.writeFileSync(cli.flags.out, compiler_output);
+}
+
+function getCompile() {
+    switch(cli.flags.stage) {
+        case "1":
+            return stage1_compile;
+        case "2":
+            return stage2_compile;
+        case "0":
+        default:
+            return stage0_compile;
+    }
 }
 
 runSchism().catch((e) => {


### PR DESCRIPTION
This also adds the `--stage` flag to specify which stage to use. Useful
when developing schism itself.

```
~ schism --help
(node:46037) ExperimentalWarning: The ESM module loader is experimental.

  A self-hosting Scheme to WebAssembly compiler

  Usage
    $ schism <input>

  Options
    --version             Show the version number
    --help                Show the help message
    -o, --out [out.wasm]  Specify a file to write the wasm to
    --stage [0]           Specify which stage compiler to use
```