### PR TITLE
Reduce default memory size to 256 MiB

### DIFF
--- a/rt/rt.mjs
+++ b/rt/rt.mjs
@@ -138,7 +138,7 @@ class Module {
 
 export class Engine {
     constructor() {
-        this.memory = new WebAssembly.Memory({ initial: 16384 });
+        this.memory = new WebAssembly.Memory({ initial: 4096 });
         this.mem_i32 = new Uint32Array(this.memory.buffer);
         this.rt = rt(this);
         this.input_port_data = [];


### PR DESCRIPTION
Fixes #56

The compiler uses significantly less memory now that the allocator doesn't over-allocate by a factor of eight (#43), so we can get by with a smaller memory size.