### PR TITLE
Simplify interface to compiler

### DIFF
--- a/bootstrap-from-guile.scm
+++ b/bootstrap-from-guile.scm
@@ -29,13 +29,12 @@
   #:use-module (schism compiler))
 
 (define* (main #:optional (out "schism-stage0.wasm") (in "schism/compiler.ss"))
-  (let ((package (with-input-from-file in compile-stdin->module-package)))
-    (with-output-to-file out
-      (lambda ()
-        ;; Schism uses write-char to write bytes, so install the
-        ;; encoding that ensures that writing (integer->char C) writes
-        ;; the byte C, for C < 256.
-        (set-port-encoding! (current-output-port) "ISO-8859-1")
-        (compile-module-package->stdout package)))))
+  (with-output-to-file out
+    (lambda ()
+      ;; Schism uses write-char to write bytes, so install the
+      ;; encoding that ensures that writing (integer->char C) writes
+      ;; the byte C, for C < 256.
+      (set-port-encoding! (current-output-port) "ISO-8859-1")
+      (with-input-from-file in compile-stdin->stdout))))
 
 (apply main (cdr (program-arguments)))

--- a/run-utils.mjs
+++ b/run-utils.mjs
@@ -1,6 +1,6 @@
 // -*- javascript -*-
 //
-// Copyright 2018 Google LLC
+// Copyright 2018, 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -51,8 +51,7 @@ function make_compiler(compiler_bytes) {
     const engine = new Schism.Engine;
     const schism = await engine.loadWasmModule(await compiler_bytes());
     engine.setCurrentInputPort(bytes);
-    let module_package = schism.exports['compile-stdin->module-package']();
-    schism.exports['compile-module-package->stdout'](module_package);
+    schism.exports['compile-stdin->stdout']();
     return new Uint8Array(engine.output_data);
   }
 }


### PR DESCRIPTION
Now that we are using the host GC, there's no need to have an explicit
concept of module packages.