### PR TITLE
Equal

### DIFF
--- a/lib/schism.ss
+++ b/lib/schism.ss
@@ -14,7 +14,7 @@
 
 ;; This library contains non-standard Schism-isms.
 (library (schism)
-  (export gensym list-all-eq?)
+  (export gensym)
   (import (rnrs)
           (%schism-runtime))
 
@@ -22,9 +22,4 @@
     (unless (string? t) (error 'gensym "not a string"))
     (%make-gensym t))
   
-  (define (list-all-eq? a b)
-    (if (null? a)
-        (null? b)
-        (and (not (null? b))
-             (eq? (car a) (car b))
-             (list-all-eq? (cdr a) (cdr b))))))
+  )

--- a/scheme-lib/rnrs.ss
+++ b/scheme-lib/rnrs.ss
@@ -17,7 +17,7 @@
           cadar caddar cadddr caddr cadr car cdaddr cdadr cdar cddar cdddr cddr
           cdr char->integer char-ci<? char-numeric? char-whitespace? display
           equal? fold-left fold-right integer->char length list->string list-ref
-          list-tail list? map max newline null? peek-char read read-char
+          list-tail list? map max memq newline null? peek-char read read-char
           string->list string->symbol string=? symbol->string string-append
           symbol? write write-char zero?)
   (import (schism))
@@ -115,6 +115,11 @@
   (define (cadadr p) (car (cdadr p)))
   (define (cadddr p) (car (cdddr p)))
   (define (cdaddr p) (cdr (caddr p)))
+  (define (memq x ls)
+    (cond
+     ((null? ls) #f)
+     ((eq? (car ls) x) ls)
+     (else (memq x (cdr ls)))))
   (define (assp p ls)
     (if (pair? ls)
         (if (p (caar ls))

--- a/scheme-lib/rnrs.ss
+++ b/scheme-lib/rnrs.ss
@@ -184,6 +184,7 @@
         ;; calling error here can lead to an infinite loop, so we
         ;; generate an unreachable instead.
         (%unreachable)))
+  ;; doesn't handle procedure or cyclic structure equivalence
   (define (equal? x y)
     (cond ((pair? x)
            (and (pair? y)

--- a/schism/compiler.ss
+++ b/schism/compiler.ss
@@ -169,7 +169,7 @@
                        (cons name visited)))))))
 
   (define (library-name-equal? lib1 lib2)
-    (list-all-eq? lib1 lib2))
+    (equal? lib1 lib2))
 
   (define (library-name-from-import import)
     (if (pair? import)
@@ -225,7 +225,7 @@
 
   (define (find-library-name name name-list)
     (and (pair? name-list)
-         (or (list-all-eq? name (car name-list))
+         (or (equal? name (car name-list))
              (find-library-name name (cdr name-list)))))
 
   ;; ====================== ;;
@@ -557,7 +557,7 @@
         (begin
           (display library) (newline)
           (error 'find-import "Could not find library"))
-        (if (list-all-eq? library (caar import-envs))
+        (if (equal? library (caar import-envs))
             (append-env (cdar import-envs) env)
             (find-import library (cdr import-envs) env))))
 

--- a/schism/compiler.ss
+++ b/schism/compiler.ss
@@ -66,13 +66,6 @@
             (set-diff (cdr set) sub)
             (cons (car set) (set-diff (cdr set) sub)))))
 
-  ;; TODO: move this into the library
-  (define (memq x ls)
-    (cond
-     ((null? ls) #f)
-     ((eq? (car ls) x) ls)
-     (else (memq x (cdr ls)))))
-
   (define (runtime-imports)
     '((bool eq? (scm x) (scm y))
 

--- a/test/equal.ss
+++ b/test/equal.ss
@@ -1,0 +1,71 @@
+;; Copyright 2020 Google LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the License);
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an AS IS BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(library (equal)
+  (export do-test)
+  (import (rnrs) (rnrs mutable-pairs))
+
+  (define (do-test)
+    (and
+     ;; from r6rs 11.5
+     (equal? 'a 'a)
+     (equal? '(a) '(a))
+     (equal? '(a (b) c)
+             '(a (b) c))
+     (equal? "abc" "abc")
+     (equal? 2 2)
+     (let* ((x '(a))
+            (y '(a))
+            (z `(,x ,y)))
+       (and (equal? z `(,y ,x))
+            (equal? z `(,x ,x))))
+     ;; from https://scheme.com/tspl4/objects.html#./objects:h2
+     (not (equal? 'a 3))
+     (not (equal? #t 't))
+     (not (equal? "abc" 'abc))
+     (not (equal? "hi" '(hi)))
+     (let ((x (* 123456789 2)))
+       (equal? x x))
+     (equal? #t #t)
+     (equal? #f #f)
+     (not (equal? #t #f))
+     (equal? (null? '()) #t)
+     (equal? (null? '(a)) #f)
+     (equal? (cdr '(a)) '())
+     (equal? 'a 'a)
+     (not (equal? 'a 'b))
+     (equal? 'a (string->symbol "a"))
+     (not (equal? '(a) '(b)))
+     (equal? '(a) '(a))
+     (let ((x '(a . b))) (equal? x x))
+     (let ((x (cons 'a 'b))) (equal? x x))
+     (equal? (cons 'a 'b) (cons 'a 'b))
+     (equal? (string->list "abc") (string->list "abc"))
+     (not (equal? "abc" "cba"))
+     (equal? "abc" "abc")
+     (let ((x "hi")) (equal? x x))
+     ;; vector/(string ...)/set!/generic numbers left out for time being
+     ;; (equal? car car)
+     ;; (not (equal? car cdr))
+     ;; fixme - infinite loop:
+     ;; (equal?
+     ;;  (let ((x (cons 'x 'x)))
+     ;;    (set-car! x x)
+     ;;    (set-cdr! x x)
+     ;;    x)
+     ;;  (let ((x (cons 'x 'x)))
+     ;;    (set-car! x x)
+     ;;    (set-cdr! x x)
+     ;;    (cons x x)))
+     )))

--- a/test/leb-u8-list-0.ss
+++ b/test/leb-u8-list-0.ss
@@ -15,8 +15,7 @@
 (library
     (trivial)
   (export do-test)
-  (import (rnrs)
-          (schism))
+  (import (rnrs))
 
   (define (number->leb-u8-list n)
     (if (and (< n #x40) (> n (- 0 #x40)))
@@ -25,4 +24,4 @@
               (number->leb-u8-list (bitwise-arithmetic-shift-right n 7)))))
 
   (define (do-test)
-    (list-all-eq? (number->leb-u8-list 0) '(0))))
+    (equal? (number->leb-u8-list 0) '(0))))

--- a/test/leb-u8-list.ss
+++ b/test/leb-u8-list.ss
@@ -15,8 +15,7 @@
 (library
     (trivial)
   (export do-test)
-  (import (rnrs)
-          (schism))
+  (import (rnrs))
 
   (define (number->leb-u8-list n)
     (if (and (< n #x40) (> n (- 0 #x40)))
@@ -25,4 +24,4 @@
               (number->leb-u8-list (bitwise-arithmetic-shift-right n 7)))))
 
   (define (do-test)
-    (list-all-eq? (number->leb-u8-list 237) '(237 1))))
+    (equal? (number->leb-u8-list 237) '(237 1))))

--- a/test/read-list.ss
+++ b/test/read-list.ss
@@ -15,8 +15,7 @@
 (library
     (trivial)
   (export do-test)
-  (import (rnrs)
-          (schism))
+  (import (rnrs))
 
   (define (do-test)
-    (list-all-eq? (read) '(1 2 #x42 #t #f))))
+    (equal? (read) '(1 2 #x42 #t #f))))

--- a/test/read-long-char-literals.ss
+++ b/test/read-long-char-literals.ss
@@ -15,8 +15,7 @@
 (library
     (trivial)
   (export do-test)
-  (import (rnrs)
-          (schism))
+  (import (rnrs))
   
   (define (do-test)
-    (list-all-eq? (read) '(#\space #\tab #\newline))))
+    (equal? (read) '(#\space #\tab #\newline))))

--- a/test/read-quote.ss
+++ b/test/read-quote.ss
@@ -15,8 +15,7 @@
 (library
     (trivial)
   (export do-test)
-  (import (rnrs)
-          (schism))
+  (import (rnrs))
 
   (define (do-test)
-    (list-all-eq? (read) ''5)))
+    (equal? (read) ''5)))


### PR DESCRIPTION
Remove `list-all-eq?`, add test for `equal?`, move `memq` to `rnrs.ss`

Figured I would do this in the meantime of figuring out how to do the `define` forms. Two questions:

The `equal?` doesn't handle cyclic structures or procedures properly, would you want this before merging? It seems hard to do the cyclic structure check efficiently without hashtables.

Would you want other functions that are in `rnrs.ss` like `filter` to also move to the library?