### PR TITLE
add list functions to rnrs.ss

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ from GNU Guile.
 As mentioned, the goal has been to prioritize features needed for self
 hosting. Here are some of the current restrictions:
 
-* Functions may only be created with `define`, and particularly only the
-  `(define (foo args ...) body)` form.
 * No use of `syntax-case`, `syntax-rules`, or `define-syntax`.
 * Only one file to start with, so we don't have to figure out how to link
   multiple libraries.
-* Only use `define` to create functions, not global variables or objects.
+* Only use `define` to create top level functions and variables.
+* Only fixed arity functions can be defined, forms such as `(define (f
+  x . args ...)` are not supported.
 * Use a small amount of syntax, because we won't have a proper macro expander at
   first. There is a pass to expand some of the simpler and more useful macros.
 * Restrict data types and operations on those. For now, we can use:

--- a/scheme-lib/rnrs.ss
+++ b/scheme-lib/rnrs.ss
@@ -13,11 +13,12 @@
 ;; limitations under the License.
 
 (library (rnrs)
-  (export > append assp assq boolean? caaar caadar caaddr caadr caar cadadr
-          cadar caddar cadddr caddr cadr car cdaddr cdadr cdar cddar cdddr cddr
-          cdr char->integer char-ci<? char-numeric? char-whitespace? display
-          equal? fold-left fold-right integer->char length list->string list-ref
-          list-tail list? map max memp memq newline null? peek-char read read-char
+  (export > append assoc assp assq boolean? caaar caadar caaddr caadr caar
+          cadadr cadar caddar cadddr caddr cadr car cdaddr cdadr cdar cddar
+          cdddr cddr cdr char->integer char-ci<? char-numeric? char-whitespace?
+          display equal? filter find fold-left fold-right integer->char length
+          list->string list-ref list-tail list? map max member memp memq
+          newline null? peek-char read read-char remove remp remq reverse
           string->list string->symbol string=? symbol->string string-append
           symbol? write write-char zero?)
   (import (schism))
@@ -115,6 +116,11 @@
   (define (cadadr p) (car (cdadr p)))
   (define (cadddr p) (car (cdddr p)))
   (define (cdaddr p) (cdr (caddr p)))
+  (define (member x ls)
+    (cond
+     ((null? ls) #f)
+     ((equal? x (car ls)) ls)
+     (else (member x (cdr ls)))))
   (define (memp p ls)
     (cond
      ((null? ls) #f)
@@ -125,6 +131,14 @@
      ((null? ls) #f)
      ((eq? (car ls) x) ls)
      (else (memq x (cdr ls)))))
+  (define (assoc x ls)
+    (if (pair? ls)
+        (if (equal? x (caar ls))
+            (car ls)
+            (assoc x (cdr ls)))
+        (if (null? ls)
+            #f
+            (begin (display x) (newline) (error 'assoc "not a list")))))
   (define (assp p ls)
     (if (pair? ls)
         (if (p (caar ls))
@@ -141,6 +155,17 @@
         (if (null? ls)
             #f
             (begin (display x) (newline) (error 'assq "not a list")))))
+  (define (find pred ls)
+    (and (pair? ls)
+         (if (pred (car ls))
+             (car ls)
+             (find pred (cdr ls)))))
+  (define (remove x ls)
+    (filter (lambda (y) (not (equal? x y))) ls))
+  (define (remp pred ls)
+    (filter (lambda (y) (not (pred y))) ls))
+  (define (remq x ls)
+    (filter (lambda (y) (not (eq? x y))) ls))
   (define (length ls)
     (cond
      ((null? ls) 0)
@@ -154,6 +179,10 @@
     (car (list-tail list n)))
   (define (append a b)
     (fold-right cons b a))
+  (define (filter pred ls)
+    (fold-right (lambda (x ls) (if (pred x) (cons x ls) ls)) '() ls))
+  (define (reverse ls)
+    (fold-left (lambda (x y) (cons y x)) '() ls))
   (define (char->integer c)
     (if (char? c)
         (%char-value c)

--- a/scheme-lib/rnrs.ss
+++ b/scheme-lib/rnrs.ss
@@ -16,11 +16,11 @@
   (export > append assoc assp assq boolean? caaar caadar caaddr caadr caar
           cadadr cadar caddar cadddr caddr cadr car cdaddr cdadr cdar cddar
           cdddr cddr cdr char->integer char-ci<? char-numeric? char-whitespace?
-          display equal? filter find fold-left fold-right integer->char length
-          list->string list-ref list-tail list? map max member memp memq
-          newline null? peek-char read read-char remove remp remq reverse
-          string->list string->symbol string=? symbol->string string-append
-          symbol? write write-char zero?)
+          display even? equal? filter find fold-left fold-right integer->char
+          iota length list->string list-ref list-tail list? map max member memp
+          memq newline null? odd? peek-char read read-char remove remp remq
+          reverse string->list string->symbol string=? symbol->string
+          string-append symbol? write write-char zero?)
   (import (schism))
 
   (define (display x)
@@ -166,6 +166,15 @@
     (filter (lambda (y) (not (pred y))) ls))
   (define (remq x ls)
     (filter (lambda (y) (not (eq? x y))) ls))
+  (define ($iota i n)
+    (if (eq? i n)
+        '()
+        (cons i ($iota (+ i 1) n))))
+  (define (iota n)
+    (unless (and (number? n) (< -1 n))
+      ;; number? is currently valid because all numbers are i32
+      (error 'iota "not a nonnegative fixnum"))
+    ($iota 0 n))
   (define (length ls)
     (cond
      ((null? ls) 0)
@@ -248,6 +257,10 @@
     (< b a))
   (define (max a b)
     (if (< a b) b a))
+  (define (even? x)
+    (eq? 0 (mod0 x 2)))
+  (define (odd? x)
+    (not (eq? 0 (mod0 x 2))))
   (define (peek-char)
     (let ((i (%peek-char)))
       (if (< i 0)

--- a/test/assoc.ss
+++ b/test/assoc.ss
@@ -1,0 +1,29 @@
+;; Copyright 2020 Google LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the License);
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an AS IS BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(library (test assoc)
+  (export do-test)
+  (import (rnrs)
+          (rnrs mutable-pairs))
+
+  (define alist
+    `((2 . a) (3 . b)))
+
+  (define (do-test)
+    (set-cdr! (assoc 3 alist) 'c)
+    (and (equal? (assoc '(a) '(((a) . a) (-1 . b)))
+                 '((a) . a))
+         (not (assoc '(a) '(((b) . b) (a . c))))
+         (equal? alist
+                 `((2 . a) (3 . c))))))

--- a/test/assq.ss
+++ b/test/assq.ss
@@ -1,0 +1,23 @@
+;; Copyright 2020 Google LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the License);
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an AS IS BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(library (test assq)
+  (export do-test)
+  (import (rnrs))
+
+  (define (do-test)
+    (and (equal? '(b . 2)
+                 (assq 'b '((a . 1) (b . 2))))
+         (eq? 2 (cdr (assq 'b '((a . 1) (b . 2)))))
+         (not (assq 'c '((a . 1) (b . 2)))))))

--- a/test/even.ss
+++ b/test/even.ss
@@ -1,0 +1,24 @@
+;; Copyright 2020 Google LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the License);
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an AS IS BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(library (test even)
+  (export do-test)
+  (import (rnrs))
+
+  (define (do-test)
+    (and (even? 0)
+         (even? 2)
+         (even? -2)
+         (not (even? -1))
+         (not (even? 3)))))

--- a/test/filter.ss
+++ b/test/filter.ss
@@ -1,0 +1,24 @@
+;; Copyright 2020 Google LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the License);
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an AS IS BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(library (test filter)
+  (export do-test)
+  (import (rnrs))
+
+  (define (do-test)
+    (and (equal? (filter (lambda (x) (and (> x 0) (< x 10)))
+                         '(-5 15 3 14 -20 6 0 -9))
+                 '(3 6))
+         (equal? (filter odd? (iota 5))
+                 '(1 3)))))

--- a/test/find.ss
+++ b/test/find.ss
@@ -1,0 +1,23 @@
+;; Copyright 2020 Google LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the License);
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an AS IS BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(library (test find)
+  (export do-test)
+  (import (rnrs))
+
+  (define (do-test)
+    (and (eq? 3 (find odd? '(2 3 5 7 11)))
+         (eq? 2 (find even? '(2 3 5 7 11)))
+         (not (find even? '(3 5 7 11)))
+         (not (find (lambda (x) (not x)) '(2 3 #f 7 11))))))

--- a/test/iota.ss
+++ b/test/iota.ss
@@ -1,0 +1,21 @@
+;; Copyright 2020 Google LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the License);
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an AS IS BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(library (test iota)
+  (export do-test)
+  (import (rnrs))
+
+  (define (do-test)
+    (and (equal? '(0 1 2) (iota 3))
+         (null? (iota 0)))))

--- a/test/odd.ss
+++ b/test/odd.ss
@@ -1,0 +1,24 @@
+;; Copyright 2020 Google LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the License);
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an AS IS BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(library (test odd)
+  (export do-test)
+  (import (rnrs))
+
+  (define (do-test)
+    (and (not (odd? 0))
+         (not (odd? 2))
+         (not (odd? -2))
+         (odd? -1)
+         (odd? 3))))

--- a/test/remove.ss
+++ b/test/remove.ss
@@ -1,0 +1,21 @@
+;; Copyright 2020 Google LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the License);
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an AS IS BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(library (test remove)
+  (export do-test)
+  (import (rnrs))
+
+  (define (do-test)
+    (equal? (remove '(b) '((a) (b) (c)))
+            '((a) (c)))))

--- a/test/remp.ss
+++ b/test/remp.ss
@@ -1,0 +1,24 @@
+;; Copyright 2020 Google LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the License);
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an AS IS BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(library (test remp)
+  (export do-test)
+  (import (rnrs))
+
+  (define (do-test)
+    (and (equal? (remp odd? '(1 2 3 4))
+                 '(2 4))
+         (equal? (remp (lambda (x) (and (> x 0) (< x 10)))
+                       '(-5 15 3 14 -20 6 0 -9))
+                 '(-5 15 14 -20 0 -9)))))

--- a/test/remq.ss
+++ b/test/remq.ss
@@ -1,0 +1,21 @@
+;; Copyright 2020 Google LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the License);
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an AS IS BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(library (test remq)
+  (export do-test)
+  (import (rnrs))
+
+  (define (do-test)
+    (and (equal? (remq 'a '(a b a c a d)) '(b c d))
+         (equal? (remq 'a '(b c d)) '(b c d) ))))

--- a/test/reverse.ss
+++ b/test/reverse.ss
@@ -1,0 +1,22 @@
+;; Copyright 2020 Google LLC
+;;
+;; Licensed under the Apache License, Version 2.0 (the License);
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an AS IS BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(library (test reverse)
+  (export do-test)
+  (import (rnrs))
+
+  (define (do-test)
+    (and (null? (reverse '()))
+         (equal? (reverse '(c b a))
+                 '(a b c)))))


### PR DESCRIPTION
* Adds rnrs list functions `filter`, `find`, `assoc`, `member`, `remove`, `remq`, `remp`, and `reverse` to `rnrs.ss`
* Replaces uses of `filter-out` with `remp`
* Add comment about `memp` while parsing variable definitions
* Update readme to reflect added define forms
* Rewrite quadratic `fold-left` with `append` as `fold-right` in `parse-libraries`

I'm supposing it'd be best to add tests for the added functions? One test per function or would it be ok to group them together in something like `test/rnrs-list-functions.ss`?